### PR TITLE
added stubbing functions feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set(PMUESTIMATOR_SRCS
 
 # Add header files
 set(PMUESTIMATOR_HEADERS
+        src/func_stubs.h
         src/pmu_estimator.h
         libs/iniparser/dictionary.h
         libs/iniparser/iniparser.h
@@ -67,4 +68,5 @@ configure_file(config/config.ini config.ini COPYONLY)
 configure_file(config/m_class_config.ini m_class_config.ini COPYONLY)
 configure_file(config/p_class_config.ini p_class_config.ini COPYONLY)
 configure_file(src/pmu_estimator.h ${CMAKE_BINARY_DIR}/pmu_estimator.h COPYONLY)
+configure_file(src/func_stubs.h ${CMAKE_BINARY_DIR}/func_stubs.h COPYONLY)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PMU Estimator
 An ANSI C implementation of the Phasor Measurment Unit Estimator (PMU Estimator) based on the Iterative Interpolated DFT Synchrophasor Estimation Algorithm.
-# Version 1.4.8
+# Version 1.4.9
 Updates (with respect to version 1.3.0):
 
 - Now the library supprots CMake Building!
@@ -13,6 +13,7 @@ Updates (with respect to version 1.3.0):
 - fixed bug of __wrap_angle()__ low result accuracy.
 - fixed bug in CmakeLists.txt that caused the library to raise an error when building with __NUM_CHANLS__ not set.
 - added library installation with cmake.
+- now it's easily possible to stub the arithmetic functions with user implementations.
 
 ## __Building the library__
 To build the library, first make sure that you have the following build tools are installed:
@@ -71,6 +72,19 @@ or add the __-DDEBUG=ON__ with the __cmake__:
 
     cmake -DDEBUG=ON ..
 
+## __Stub Arithmetic functions__
+__func_stub.c__ is a header file that defines macros to stub out several data types and functions.
+ In the file you can use the macros to either implement your own version of a function or to replace it with a version from an external library.
+ 
+ __For example:__ if you want to implement your own version of the __pmue_fft_r__ function, you can define a new function with the same name and signature, and then use the __pmue_fft_r__ macro to replace the original function with your new implementation:
+
+    #define pmue_fft_r(in_ptr, out_ptr, out_len, n_bins) my_fft((in_ptr), (out_ptr), (out_len), (n_bins))
+
+    int_p my_fft(float_p* in_ptr, float_p complex_p* out_ptr , uint_p out_len, uint_p n_bins) {
+        //Your implementation of fft here
+    }
+
+Note that if you want to use a function from an external library, you will need to link the library to your code during the compilation process.
 ## __Pmu Estimator Configuration__
 
 In order to configure the program, the __config.ini__ which can be found in __config/config.ini__ file must be edited. otherwise pass config structure to the __pmu_init()__ function.

--- a/build.sh
+++ b/build.sh
@@ -73,6 +73,7 @@ cp config.ini ../build/config
 cp m_class_config.ini ../build/config
 cp p_class_config.ini ../build/config
 cp pmu_estimator.h ../build/headers
+cp func_stubs.h ../build/headers
 
 # remove the cmake_build folder
 cd ..

--- a/examples/simple_example.c
+++ b/examples/simple_example.c
@@ -6,17 +6,17 @@
 int main() {
 
     // Input Signal parameters
-    double AMP = 2;
-    double PH = 1;
-    double FREQ = 50;
-    unsigned int sample_rate = 25600;
-    unsigned int window_size = 2048;
-    double dt = 1/(double)sample_rate;
+    float_p AMP = 2;
+    float_p PH = 1;
+    float_p FREQ = 50;
+    uint_p sample_rate = 25600;
+    uint_p window_size = 2048;
+    float_p dt = 1/(float_p)sample_rate;
 
-    double input_signal_window[window_size];
+    float_p input_signal_window[window_size];
 
     // Initializing input signal window
-    unsigned int i;
+    uint_p i;
     for(i=0; i<window_size; i++){
         input_signal_window[i] = AMP*cos(2*M_PI*FREQ*dt*i + PH);
     }
@@ -26,10 +26,10 @@ int main() {
     pmu_init(&file_name, CONFIG_FROM_INI);
 
     pmu_frame estimated_frame;
-    double mid_window_fracsec = 0;
+    float_p mid_window_fracsec = 0;
 
     // Estimating frame
-    pmu_estimate((double *)input_signal_window, mid_window_fracsec , &estimated_frame);
+    pmu_estimate((float_p *)input_signal_window, mid_window_fracsec , &estimated_frame);
     
     // Printing estimated frame
     pmu_dump_frame(&estimated_frame, stdout);

--- a/examples/simple_example2.c
+++ b/examples/simple_example2.c
@@ -6,17 +6,17 @@
 int main() {
 
     // Input Signal parameters
-    double AMP = 2;
-    double PH = 1;
-    double FREQ = 50;
-    unsigned int sample_rate = 25600;
-    unsigned int window_size = 2048;
-    double dt = 1/(double)sample_rate;
+    float_p AMP = 2;
+    float_p PH = 1;
+    float_p FREQ = 50;
+    uint_p sample_rate = 25600;
+    uint_p window_size = 2048;
+    float_p dt = 1/(float_p)sample_rate;
 
-    double input_signal_window[window_size];
+    float_p input_signal_window[window_size];
 
     // Initializing input signal window
-    unsigned int i;
+    uint_p i;
     for(i=0; i<window_size; i++){
         input_signal_window[i] = AMP*cos(2*M_PI*FREQ*dt*i + PH);
     }
@@ -45,10 +45,10 @@ int main() {
     pmu_init(&pmu_config, CONFIG_FROM_STRUCT);
 
     pmu_frame estimated_frame;
-    double mid_window_fracsec = 0;
+    float_p mid_window_fracsec = 0;
 
     // Estimating frame
-    pmu_estimate((double *)input_signal_window, mid_window_fracsec , &estimated_frame);
+    pmu_estimate((float_p *)input_signal_window, mid_window_fracsec , &estimated_frame);
     
     // Printing estimated frame
     pmu_dump_frame(&estimated_frame, stdout);

--- a/src/func_stubs.h
+++ b/src/func_stubs.h
@@ -1,0 +1,145 @@
+#ifndef FUNC_STUBS_H
+#define FUNC_STUBS_H
+
+/*==============================================================================
+  @file func_stubs.h
+
+  Pmu estimator functions stubs. 
+
+  Authors: Chemseddine Allioua, Brahim Mazighi 
+
+  Copyright (c) 2023.
+  All Rights Reserved.
+  Confidential and Proprietary - University of Bologna.
+ 
+  This header file defines macros to stub out arithmetic functions and data types.
+  The macros replace the function name with acorresponding "pmue_" function that 
+  you define, allowing you to implement your own versions of these functions with 
+  the behavior that you want. You can also stub out a function using an external 
+  library function, if you include the necessary headers and link with the library.
+ 
+==============================================================================*/ 
+
+
+#include <math.h>
+#include <complex.h>
+
+/* Define a macro to stub constants ===========================================*/
+
+/* Define a macro to stub out M_PI */
+#define M_PI_p M_PI
+
+/* Define a macro to stub data types ==========================================*/
+
+/* Define a macro to stub out the float data type function */
+#define float_p double
+
+
+/* Define a macro to stub out the complex data type function */
+#define complex_p complex
+
+
+/* Define a macro to stub out the complex data type function */
+#define uint_p unsigned int
+
+/* Define a macro to stub out the complex data type function */
+#define bool_p _Bool
+
+
+/* Define a macro to stub function ==========================================*/
+
+/* Define a macro to stub out the fft for real input function */
+/*
+#define pmue_fft_r(in_ptr, out_ptr, out_len, n_bins) my_fft((in_ptr), (out_ptr), (out_len), (n_bins))
+
+int_p my_fft(float_p* in_ptr, float_p complex_p* out_ptr , uint_p out_len, uint_p n_bins) {
+    //Your implementation of exp here
+}
+*/
+
+#ifndef pmue_fft_r
+#define pmue_fft_r(in_ptr, out_ptr, out_len, n_bins) dft_r(in_ptr, out_ptr, out_len, n_bins)
+#endif
+
+/* Define a macro to stub out the cabs for complex input */
+/*
+#define pmue_cabs(x) my_cabs(x)
+
+float_p my_cabs(float_p complex_p x) {
+    //Your implementation of exp here
+}
+*/
+
+#ifndef pmue_cabs
+#define pmue_cabs(x) cabs(x)
+#endif
+
+/* Define a macro to stub out the cabs for real input */
+/*
+#define pmue_fabs(x) my_fabs(x)
+
+float_p my_fabs(float_p x) {
+    //Your implementation of exp here
+}
+*/
+#ifndef pmue_fabs
+#define pmue_fabs(x) fabs(x)
+#endif
+
+/* Define a macro to stub out the carg for real input */
+/*
+#define pmue_carg(x) my_carg(x)
+
+float_p my_carg(complex_p x) {
+    //Your implementation of exp here
+}
+*/
+
+/* Define a macro to stub out the carg function */
+#ifndef pmue_carg
+#define pmue_carg(x) carg(x)
+#endif
+
+/* Define a macro to stub out the cos function */
+/*
+#define pmue_cos(x) my_cos(x)
+
+float_p my_cos(float_p x) {
+    //Your implementation of exp here
+}
+*/
+
+/* Define a macro to stub out the cos function */
+#ifndef pmue_cos
+#define pmue_cos(x) cos(x)
+#endif
+
+/* Define a macro to stub out the sin function */
+/*
+#define pmue_sin(x) my_sin(x)
+
+float_p my_sin(float_p x) {
+    //Your implementation of exp here
+}
+*/
+
+/* Define a macro to stub out the sin function */
+#ifndef pmue_sin
+#define pmue_sin(x) sin(x)
+#endif
+
+/* Define a macro to stub out the sin function */
+/*
+#define pmue_cexp(x) my_cexp(x)
+
+float_p my_cexp(complex_p x) {
+    //Your implementation of exp here
+}
+*/
+
+/* Define a macro to stub out the cexp function */
+#ifndef pmue_cexp
+#define pmue_cexp(x) cexp(x)
+#endif
+
+#endif /* FUNC_STUBS_H */

--- a/src/pmu_estimator.h
+++ b/src/pmu_estimator.h
@@ -11,6 +11,7 @@
 
 ==============================================================================*/ 
 #include <stdio.h>
+#include "func_stubs.h"
 
 #ifndef PMU_ESTIMATOR_H
 #define PMU_ESTIMATOR_H
@@ -33,35 +34,35 @@ extern "C" {
 #define CONFIG_FROM_STRUCT 0
 
 typedef struct {
-    unsigned int n_cycles;
-    unsigned int f0;
-    unsigned int frame_rate;
-    unsigned int fs;
-    unsigned int n_bins;
-    unsigned int P;
-    unsigned int Q;
-    _Bool iter_eipdft;
-    double interf_trig;
-    double rocof_thresh[3];
-    double rocof_low_pass_coeffs[3];
+    uint_p n_cycles;
+    uint_p f0;
+    uint_p frame_rate;
+    uint_p fs;
+    uint_p n_bins;
+    uint_p P;
+    uint_p Q;
+    bool_p iter_eipdft;
+    float_p interf_trig;
+    float_p rocof_thresh[3];
+    float_p rocof_low_pass_coeffs[3];
 } estimator_config;
 
 typedef struct{
-    double amp;
-    double ph;
-    double freq;
+    float_p amp;
+    float_p ph;
+    float_p freq;
 }phasor;
 
 typedef struct{
     phasor synchrophasor;
-    double rocof;
+    float_p rocof;
 }pmu_frame;
 
 //pmu estimator initialization
-int pmu_init(void* cfg, _Bool config_from_ini);
+int pmu_init(void* cfg, bool_p config_from_ini);
 
 //synchrophasor, frequency, rocof estimation
-int pmu_estimate(double *in_signal_windows, double mid_fracsec ,pmu_frame* out_frame);
+int pmu_estimate(float_p *in_signal_windows, float_p mid_fracsec ,pmu_frame* out_frame);
 
 //pmu estimator deinitialization
 int pmu_deinit();
@@ -73,4 +74,4 @@ int pmu_dump_frame(pmu_frame *frame, FILE *stream);
 }
 #endif
 
-#endif /* ITER_E_IPDFT_IMP_H */
+#endif /* PMU_ESTIMATOR_H */


### PR DESCRIPTION
## __Stub Arithmetic functions__
__func_stub.c__ is a header file that defines macros to stub out several data types and functions.
 In the file you can use the macros to either implement your own version of a function or to replace it with a version from an external library.
 
 __For example:__ if you want to implement your own version of the __pmue_fft_r__ function, you can define a new function with the same name and signature, and then use the __pmue_fft_r__ macro to replace the original function with your new implementation:

    #define pmue_fft_r(in_ptr, out_ptr, out_len, n_bins) my_fft((in_ptr), (out_ptr), (out_len), (n_bins))

    int_p my_fft(float_p* in_ptr, float_p complex_p* out_ptr , uint_p out_len, uint_p n_bins) {
        //Your implementation of fft here
    }

Note that if you want to use a function from an external library, you will need to link the library to your code during the compilation process.