### PR TITLE
fix: correct allocation error strings

### DIFF
--- a/src/pmu_estimator.c
+++ b/src/pmu_estimator.c
@@ -119,12 +119,12 @@ int pmu_init(pmu_context *ctx, void *cfg, bool_p config_from_ini)
     }
     if (NULL == (ctx->buff_params.dftbins = malloc(ctx->synch_params.win_len * sizeof(float_p complex_p))))
     {
-        error("[%s] ERROR: ctx->buff_params.Xi memory allocation failed\n", __FUNCTION__);
+        error("[%s] ERROR: ctx->buff_params.dftbins memory allocation failed\n", __FUNCTION__);
         return -1;
     }
     if (NULL == (ctx->buff_params.hann_window = malloc(ctx->synch_params.win_len * sizeof(float_p))))
     {
-        error("[%s] ERROR: ctx->hann_params.win_len memory allocation failed\n", __FUNCTION__);
+        error("[%s] ERROR: ctx->buff_params.hann_window memory allocation failed\n", __FUNCTION__);
         return -1;
     }
     uint_p i;


### PR DESCRIPTION
## Summary
- fix pmu_init allocation messages to refer to correct buffer names

## Testing
- `make -C test test` *(fails: `NUM_CHANLS` undeclared)*

------
https://chatgpt.com/codex/tasks/task_e_6850fc8f4af48332a9afcb30638d01f7